### PR TITLE
Release/mandatory part

### DIFF
--- a/LOGBOOK.md
+++ b/LOGBOOK.md
@@ -52,13 +52,11 @@ Different types of processes:
 
 ## docker-compose file potential modifications
 
-- nginx
-    - ports: 127.0.0.1:443:443
-	- volumes: :ro pour read-only
+
 
 
 - rename wp-superadmin-user.txt file + change credentials
-
+- nginx default.conf file -> maybe delete some, everything is not interesting and/or useful
 
 
 ### Implementation choices

--- a/LOGBOOK.md
+++ b/LOGBOOK.md
@@ -58,3 +58,7 @@ Different types of processes:
 
 
 - rename wp-superadmin-user.txt file + change credentials
+
+
+
+### Implementation choices

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,11 @@
 export DOCKER_BUILDKIT=1
 
-DOMAIN			:= gueberso.42.fr
-
-SECRETS_PATH	:= secrets/ssl/
-CERT_PATH		:= $(SECRETS_PATH)cert.pem
-KEY_PATH		:= $(SECRETS_PATH)key.pem
-
 COMPOSE_FILE	:= srcs/docker-compose.yml
 COMPOSE_CMD		:= docker compose -f $(COMPOSE_FILE)
 
-DATA_DIR		:= /home/gueberso/data
+DOMAIN			:= gueberso.42.fr
+
+DATA_DIR		:= $(HOME)/data/
 MARIADB_DIR		:= $(DATA_DIR)/mariadb
 WORDPRESS_DIR	:= $(DATA_DIR)/wordpress
 
@@ -25,6 +21,15 @@ $(WORDPRESS_DIR):
 
 $(SECRETS_PATH):
 	mkdir -p $@
+
+SECRETS_PATH	:= secrets/ssl/
+CERT_PATH		:= $(SECRETS_PATH)cert.pem
+KEY_PATH		:= $(SECRETS_PATH)key.pem
+
+$(CERT_PATH) $(KEY_PATH): | $(SECRETS_PATH)
+	@openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
+	-subj "/C=FR/ST=France/L=Lyon/O=42Lyon/OU=DevOps/CN=$(DOMAIN)" \
+	-keyout $(KEY_PATH) -out $(CERT_PATH)
 
 .DEFAULT_GOAL	:= up
 
@@ -50,8 +55,7 @@ down:
 .PHONY: clean
 clean: down
 	docker system prune -af
-	docker volume rm $(VOLUMES)
-
+	docker volume rm $(VOLUMES) || true
 
 .PHONY: fclean
 fclean: clean
@@ -80,27 +84,11 @@ exec:
 	@if [ -z "$(word 2,$(MAKECMDGOALS))" ]; then \
 		echo "Error: Please specify SERVICE. Usage: make exec <service_name>"; \
 	else \
-		$(COMPOSE_CMD) exec $(word 2,$(MAKECMDGOALS)) /bin/sh; \
+		$(COMPOSE_CMD) exec $(word 2,$(MAKECMDGOALS)) sh; \
 	fi
-
-.PHONY: status
-status:
-	$(COMPOSE_CMD) ps
-
-.PHONY: restart
-restart:
-	$(COMPOSE_CMD) restart
-
 
 .PHONY: ssl
 ssl: $(CERT_PATH) $(KEY_PATH)
-
-
-$(CERT_PATH) $(KEY_PATH): | $(SECRETS_PATH)
-	@openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
-	-subj "/C=FR/ST=France/L=Lyon/O=42Lyon/OU=DevOps/CN=$(DOMAIN)" \
-	-keyout $(KEY_PATH) -out $(CERT_PATH)
-
 
 # For any target not explicitly defined elsewhere, do nothing and consider it successful.
 # Define dummy targets for any argument passed to logs-service and exec, to prevent Make errors

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,93 @@
-# export DOCKER_BUILDKIT=1 before we even create the ssl certificate.
-# 
+SECRETS_PATH	:= secrets/ssl/
+CERT_PATH		:= $(SECRETS_PATH)cert.pem
+KEY_PATH		:= $(SECRETS_PATH)key.pem
+
+COMPOSE_FILE	:= srcs/docker-compose.yml
+COMPOSE_CMD		:= docker compose -f $(COMPOSE_FILE)
+
+DATA_DIR		:= /home/gueberso/data
+MARIADB_DIR		:= $(DATA_DIR)/mariadb
+WORDPRESS_DIR	:= $(DATA_DIR)/wordpress
+
+export DOCKER_BUILDKIT=1
+
+.DEFAULT_GOAL	:= build
+
+.PHONY: all
+all: ssl dirs build up
+
+dirs:
+	@mkdir -p $(MARIADB_DIR)
+	@mkdir -p $(WORDPRESS_DIR)
+
+build: ssl dirs
+	$(COMPOSE_CMD) build
+
+# Start all services (build if necessary)
+up: ssl dirs
+	$(COMPOSE_CMD) up -d --build
+
+# Stop all services without removing containers
+stop:
+	$(COMPOSE_CMD) stop
+
+# Stop and remove containers, networks
+down:
+	$(COMPOSE_CMD) down
+
+# Clean: stop and remove containers, networks, and anonymous volumes
+clean: down
+	$(COMPOSE_CMD) down -v
+	@docker system prune -f
+
+# Full clean: remove everything including images and named volumes
+fclean: clean
+	$(COMPOSE_CMD) down -v --rmi all
+	@if [ -n "$$(docker volume ls -q)" ]; then \
+		docker volume rm $$(docker volume ls -q) 2>/dev/null || true; \
+	fi
+	@if [ -n "$$(docker images -q)" ]; then \
+		docker rmi -f $$(docker images -q) 2>/dev/null || true; \
+	fi
+	@docker system prune -a -f --volumes
+	@sudo rm -rf $(DATA_DIR)
+
+# Restart everything
+re: down
+	$(MAKE) build
+	$(MAKE) up
+
+# Show logs from all services
+logs:
+	$(COMPOSE_CMD) logs -f
+
+# Show logs from a specific service (usage: make logs-service SERVICE=nginx)
+logs-service:
+	@if [ -z "$(SERVICE)" ]; then \
+	else \
+		docker-compose -f $(COMPOSE_FILE) logs -f $(SERVICE); \
+	fi
+
+# Show status of all services
+status:
+	$(COMPOSE_CMD) ps
+
+# Enter a running container (usage: make exec SERVICE=nginx)
+exec:
+	@if [ -z "$(SERVICE)" ]; then \
+		echo "Error: Please specify SERVICE. Usage: make exec SERVICE=nginx$(NC)"; \
+	else \
+		docker-compose -f $(COMPOSE_FILE) exec $(SERVICE) /bin/sh; \
+	fi
+
+restart:
+	$(COMPOSE_FILE) restart
+
+
+.PHONY: ssl
+ssl: $(CERT_PATH) $(KEY_PATH)
+
+$(CERT_PATH) $(KEY_PATH): | $(SECRETS_PATH)
+	openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
+	-subj "/C=EN/ST=France/L=Lyon/O=42Lyon/OU=DevOps/CN=$(DOMAIN)" \
+	-keyout $(KEY_PATH) -out $(CERT_PATH)

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ export DOCKER_BUILDKIT=1
 COMPOSE_FILE	:= srcs/docker-compose.yml
 COMPOSE_CMD		:= docker compose -f $(COMPOSE_FILE)
 
-DOMAIN			:= gueberso.42.fr
+DOMAIN_NAME		:= gueberso.42.fr
 
 DATA_DIR		:= $(HOME)/data/
-MARIADB_DIR		:= $(DATA_DIR)/mariadb
-WORDPRESS_DIR	:= $(DATA_DIR)/wordpress
+MARIADB_DIR		:= $(DATA_DIR)mariadb
+WORDPRESS_DIR	:= $(DATA_DIR)wordpress
 
 VOLUMES 		:= \
 	mariadb \
@@ -19,16 +19,16 @@ $(MARIADB_DIR):
 $(WORDPRESS_DIR):
 	mkdir -p $@
 
-$(SECRETS_PATH):
-	mkdir -p $@
-
 SECRETS_PATH	:= secrets/ssl/
 CERT_PATH		:= $(SECRETS_PATH)cert.pem
 KEY_PATH		:= $(SECRETS_PATH)key.pem
 
+$(SECRETS_PATH):
+	mkdir -p $@
+
 $(CERT_PATH) $(KEY_PATH): | $(SECRETS_PATH)
 	@openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
-	-subj "/C=FR/ST=France/L=Lyon/O=42Lyon/OU=DevOps/CN=$(DOMAIN)" \
+	-subj "/C=FR/ST=France/L=Lyon/O=42Lyon/OU=DevOps/CN=$(DOMAIN_NAME)" \
 	-keyout $(KEY_PATH) -out $(CERT_PATH)
 
 .DEFAULT_GOAL	:= up

--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "443:443"
     volumes:
-      - wordpress_data:/var/www/html
+      - wordpress_data:/var/www/html:ro
     networks:
       - inception
     init: true
@@ -59,7 +59,7 @@ services:
       - mariadb_database
       - mariadb_user
       - mariadb_password
-      - wp-superadmin-user
+      - wp_admin
     env_file: .env
 
 
@@ -93,8 +93,8 @@ secrets:
     file: ../secrets/mariadb/mariadb_root_password.txt
   mariadb_user:
     file: ../secrets/mariadb/mariadb_user.txt
-  wp-superadmin-user:
-    file: ../secrets/wordpress/wp-superadmin-user.txt
+  wp_admin:
+    file: ../secrets/wordpress/wp_admin.txt
   # commented for now because we're generation the certificate and the key at container creation
   # need to move it to Makefile, as first thing to do so it runs once and we don't recreate certification + key everytime the files are modified
   # Also will allow us to remove nginx Dockerfile dependencies -> will only have to mount files in the container.

--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -2,12 +2,14 @@ services:
   nginx:
     container_name: nginx
     build: requirements/nginx
+    # testing 127.0.0.1 port
     ports:
-      - "443:443"
+      - "127.0.0.1:443:443"
     volumes:
       - wordpress_data:/var/www/html:ro
     networks:
       - inception
+    # runs tini as foreground process
     init: true
     restart: always
     healthcheck:
@@ -19,9 +21,9 @@ services:
     depends_on:
       wordpress:
         condition: service_started
-    # secrets:
-    #   - ssl_certification
-    #   - ssl_key
+    secrets:
+      - ssl_certificate
+      - ssl_key
 
   mariadb:
     container_name: mariadb
@@ -78,12 +80,12 @@ volumes:
       o: bind
       device: /home/gueberso/data/wordpress
 
+
 networks:
   inception:
     driver: bridge
 
 
-# Secret files
 secrets:
   mariadb_database:
     file: ../secrets/mariadb/mariadb_database.txt
@@ -95,10 +97,7 @@ secrets:
     file: ../secrets/mariadb/mariadb_user.txt
   wp_admin:
     file: ../secrets/wordpress/wp_admin.txt
-  # commented for now because we're generation the certificate and the key at container creation
-  # need to move it to Makefile, as first thing to do so it runs once and we don't recreate certification + key everytime the files are modified
-  # Also will allow us to remove nginx Dockerfile dependencies -> will only have to mount files in the container.
-  # ssl_certification:
-  #   file: ../secrets/ssl/gueberso.42.fr.crt
-  # ssl_key:
-  #   file: ../secrets/ssl/gueberso.42.fr.key
+  ssl_certificate:
+    file: ../secrets/ssl/cert.pem
+  ssl_key:
+    file: ../secrets/ssl/key.pem

--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -68,12 +68,14 @@ services:
 # Top-level ressources configuration
 volumes:
   mariadb_data:
+    name: mariadb
     driver: local
     driver_opts:
       type: none
       o: bind
       device: /home/gueberso/data/mariadb
   wordpress_data:
+    name: wordpress
     driver: local
     driver_opts:
       type: none

--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       - mariadb_user
       - mariadb_password
       - wp_admin
+      - wp_public_user_password
     env_file: .env
 
 
@@ -98,6 +99,8 @@ secrets:
     file: ../secrets/mariadb/mariadb_user.txt
   wp_admin:
     file: ../secrets/wordpress/wp_admin.txt
+  wp_public_user_password:
+    file: ../secrets/wordpress/wp_public_user_password.txt
   ssl_certificate:
     file: ../secrets/ssl/cert.pem
   ssl_key:

--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -65,7 +65,6 @@ services:
     env_file: .env
 
 
-# Top-level ressources configuration
 volumes:
   mariadb_data:
     name: mariadb

--- a/srcs/requirements/bonus/static-website/Dockerfile
+++ b/srcs/requirements/bonus/static-website/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.21
+
+WORKDIR /var/www
+
+COPY website/ .
+
+EXPOSE 8080
+
+CMD ["busybox", "httpd", "-f", "-v", "-p", "8080"]
+
+# https://wiki.alpinelinux.org/wiki/BusyBox
+# https://hub.docker.com/_/busybox
+# https://linux.die.net/man/1/busybox
+
+# busybox devient httpd
+# -f do not daemonize ? need tini ? on va voir
+# -v verbose
+# -p port binding -> 8080
+

--- a/srcs/requirements/mariadb/tools/entrypoint.sh
+++ b/srcs/requirements/mariadb/tools/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 
-# Read secrets from files
 MARIADB_DATABASE=$(cat /run/secrets/mariadb_database)
 MARIADB_PASSWORD=$(cat /run/secrets/mariadb_password)
 MARIADB_ROOT_PASSWORD=$(cat /run/secrets/mariadb_root_password)

--- a/srcs/requirements/nginx/Dockerfile
+++ b/srcs/requirements/nginx/Dockerfile
@@ -3,21 +3,11 @@
 FROM alpine:3.21
 
 # Added curl so the healtcheck can run properly
-RUN apk add --no-cache nginx openssl curl
+RUN apk add --no-cache nginx curl
 
 COPY conf/nginx.conf /etc/nginx/nginx.conf
 COPY conf/default.conf /etc/nginx/http.d/
 
-RUN mkdir -p /etc/nginx/ssl
-
-# Need to check what this does
-RUN openssl req -x509 -newkey rsa:4096 \
-    -keyout /etc/nginx/ssl/key.pem \
-    -out /etc/nginx/ssl/cert.pem \
-    -sha256 -days 365 -nodes \
-    -subj "/C=FR/ST=France/L=Lyon/O=42lyon/OU=DevOps/CN=localhost"
-
 EXPOSE 443
 
-# Still need to check what each of those parameter does
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/srcs/requirements/nginx/conf/default.conf
+++ b/srcs/requirements/nginx/conf/default.conf
@@ -1,27 +1,11 @@
-# server {
-#  	listen 443 ssl;
-#  	listen [::]:443 ssl default_server;
-
-#  	# Catch-all server name for unmatched requests
-#  	server_name gueberso.42.fr;
-
-#  	# Certificate management
-#  	ssl_certificate /etc/nginx/ssl/cert.pem;
-#  	ssl_certificate_key /etc/nginx/ssl/key.pem;
-
-#  	# pre-requisite for the WordPress webpage
-#  	# the root is a directive for nginx to tell it where the home of the website file are
-#  	# root /var/www/html;
-# }
-
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
 
     server_name gueberso.42.fr;
 
-    ssl_certificate /etc/nginx/ssl/cert.pem;
-    ssl_certificate_key /etc/nginx/ssl/key.pem;
+    ssl_certificate /run/secrets/ssl_certificate;
+    ssl_certificate_key /run/secrets/ssl_key;
     ssl_protocols TLSv1.2 TLSv1.3;
 
     root /var/www/html;

--- a/srcs/requirements/wordpress/Dockerfile
+++ b/srcs/requirements/wordpress/Dockerfile
@@ -3,14 +3,11 @@
 FROM alpine:3.21
 
 RUN apk add --no-cache \
-	# process manager needed for nginx to serve php
 	php83 \
 	php83-phar \
 	php83-fpm \
 	php83-mysqli \
-	# handle multibyte string, required by WordPress
 	php83-mbstring \
-	# performance improvement
 	php83-opcache \
 	# importing redis since we'll need to for the bonus service
 	redis \
@@ -36,6 +33,3 @@ RUN adduser -D -S -G www-data -u 82 www-data
 ENTRYPOINT [ "./entrypoint.sh" ]
 
 CMD ["php-fpm83", "-F"]
-
-# potential helper later on
-# RUN ln -sf /usr/bin/php83 /usr/bin/php || true

--- a/srcs/requirements/wordpress/tools/entrypoint.sh
+++ b/srcs/requirements/wordpress/tools/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 MARIADB_DATABASE=$(cat /run/secrets/mariadb_database)
 MARIADB_PASSWORD=$(cat /run/secrets/mariadb_password)
 MARIADB_USER=$(cat /run/secrets/mariadb_user)
-WP_ADMIN_USER=$(cat /run/secrets/wp-superadmin-user)
+WP_ADMIN_USER=$(cat /run/secrets/wp_admin)
 
 mkdir -p /var/www/html
 chown -R www-data:www-data /var/www/html
@@ -24,19 +24,19 @@ if [ ! -f wp-config.php ]; then
     if ! wp core is-installed --allow-root; then
             wp core install \
                 --url="https://$DOMAIN" \
-                --title="Fkin Website" \
+                --title="Homepage" \
                 --admin_user="$WP_ADMIN_USER" \
                 --admin_password="$MARIADB_PASSWORD" \
                 --admin_email="admin@$DOMAIN" \
                 --skip-email \
                 --allow-root
-        # Create a regular non-admin user
-        # wp user create \
-        #     regularuser \
-        #     "user@$DOMAIN" \
-        #     --user_pass="userpass123" \
-        #     --role=subscriber \
-        #     --allow-root
+
+            wp user create \
+                public_user \
+                "public_user@$DOMAIN" \
+                --user_pass="42" \
+                --role=subscriber \
+                --allow-root
 
         echo "WordPress installation completed!"
     else
@@ -45,6 +45,3 @@ if [ ! -f wp-config.php ]; then
 fi
 
 exec "$@"
-
-
-

--- a/srcs/requirements/wordpress/tools/entrypoint.sh
+++ b/srcs/requirements/wordpress/tools/entrypoint.sh
@@ -5,6 +5,7 @@ MARIADB_DATABASE=$(cat /run/secrets/mariadb_database)
 MARIADB_PASSWORD=$(cat /run/secrets/mariadb_password)
 MARIADB_USER=$(cat /run/secrets/mariadb_user)
 WP_ADMIN_USER=$(cat /run/secrets/wp_admin)
+PUBLIC_USER_PASSWORD=$(cat /run/secrets/wp_public_user_password)
 
 mkdir -p /var/www/html
 chown -R www-data:www-data /var/www/html
@@ -34,7 +35,7 @@ if [ ! -f wp-config.php ]; then
             wp user create \
                 public_user \
                 "public_user@$DOMAIN" \
-                --user_pass="42" \
+                --user_pass="$PUBLIC_USER_PASSWORD" \
                 --role=subscriber \
                 --allow-root
 


### PR DESCRIPTION
This pull request introduces improvements and refactors to the Docker Compose setup and related configuration files, focusing on better secrets management, improved Makefile automation, and more secure and maintainable service configurations. The most significant changes include moving SSL certificate generation to the Makefile, updating secrets handling, and cleaning up service definitions for nginx and WordPress.

**Infrastructure and automation improvements:**

* Added a comprehensive `Makefile` that automates Docker Compose commands, manages SSL certificate generation, and handles data and secrets directories for easier setup and teardown.
* SSL certificate and key are now generated and managed outside the nginx container, improving security and avoiding unnecessary regeneration; nginx now uses secrets for SSL files.

**Secrets and configuration refactoring:**

* Updated Docker Compose secrets: added `ssl_certificate` and `ssl_key` secrets; services now consume these secrets directly.
* Updated WordPress and MariaDB entrypoint scripts to use the new secrets file names and improved user creation logic in WordPress setup.

**Service configuration and security:**

* Nginx service now binds to `127.0.0.1:443` and mounts the WordPress volume as read-only, enhancing security; also cleaned up the default configuration file.
* Removed unnecessary package installations and certificate generation from the nginx Dockerfile, simplifying the build process.